### PR TITLE
Publish notifications for stream data received

### DIFF
--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -366,6 +366,16 @@ if (CYGWIN)
     endif ()
 endif ()
 
+find_package(PkgConfig)
+## use pkg-config to get hints for 0mq locations
+pkg_check_modules(PC_ZeroMQ QUIET zmq)
+
+## use the hint from above to find the location of libzmq
+find_library(ZeroMQ_LIBRARY
+        NAMES zmq
+        PATHS ${PC_ZeroMQ_LIBRARY_DIRS}
+        )
+
 target_link_libraries(
     aeron_driver
     ${CMAKE_DL_LIBS}
@@ -374,7 +384,8 @@ target_link_libraries(
     ${AERON_LIB_M_LIBS}
     ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${AERON_LIB_WINSOCK_LIBS})
+    ${AERON_LIB_WINSOCK_LIBS}
+    ${ZeroMQ_LIBRARY})
 
 target_link_libraries(
     aeronmd
@@ -385,7 +396,8 @@ target_link_libraries(
     ${AERON_LIB_M_LIBS}
     ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${AERON_LIB_WINSOCK_LIBS})
+    ${AERON_LIB_WINSOCK_LIBS}
+    ${ZeroMQ_LIBRARY})
 
 target_link_libraries(
     aeronmd_s
@@ -396,7 +408,8 @@ target_link_libraries(
     ${AERON_LIB_M_LIBS}
     ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${AERON_LIB_WINSOCK_LIBS})
+    ${AERON_LIB_WINSOCK_LIBS}
+    ${ZeroMQ_LIBRARY})
 
 target_compile_definitions(aeron_driver PRIVATE -DAERON_DRIVER)
 target_compile_definitions(aeron_driver_static PRIVATE -DAERON_DRIVER)

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -386,6 +386,7 @@ target_link_libraries(
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS}
     ${ZeroMQ_LIBRARY}
+    # Requires C++ std lib due to new ZMQ dependencies.
     stdc++)
 
 target_link_libraries(

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -16,9 +16,6 @@ include(CheckSymbolExists)
 include(CheckIncludeFile)
 include(CheckTypeSize)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
     add_definitions(-D_DEFAULT_SOURCE)
@@ -372,16 +369,11 @@ endif ()
 find_package(PkgConfig)
 ## use pkg-config to get hints for 0mq locations
 pkg_check_modules(PC_ZeroMQ QUIET zmq)
-pkg_check_modules(PC_Sodium QUIET sodium)
 
 ## use the hint from above to find the location of libzmq
 find_library(ZeroMQ_LIBRARY
         NAMES zmq
         PATHS ${PC_ZeroMQ_LIBRARY_DIRS}
-        )
-find_library(Sodium_LIBRARY
-        NAMES sodium 
-        PATHS ${PC_Sodium_LIBRARY_DIRS}
         )
 
 target_link_libraries(
@@ -394,7 +386,7 @@ target_link_libraries(
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS}
     ${ZeroMQ_LIBRARY}
-    ${Sodium_LIBRARY})
+    stdc++)
 
 target_link_libraries(
     aeronmd
@@ -407,7 +399,7 @@ target_link_libraries(
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS}
     ${ZeroMQ_LIBRARY}
-    ${Sodium_LIBRARY})
+    stdc++)
 
 # target_link_libraries(
 #  aeronmd_s
@@ -419,8 +411,7 @@ target_link_libraries(
 #    ${AERON_LIB_ATOMIC_LIBS}
 #    ${CMAKE_THREAD_LIBS_INIT}
 #    ${AERON_LIB_WINSOCK_LIBS}
-#    ${ZeroMQ_LIBRARY}
-#    ${Sodium_LIBRARY})
+#    ${ZeroMQ_LIBRARY})
 
 target_compile_definitions(aeron_driver PRIVATE -DAERON_DRIVER)
 # target_compile_definitions(aeron_driver_static PRIVATE -DAERON_DRIVER)

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -338,9 +338,9 @@ add_executable(aeronmd aeronmd.c)
 target_include_directories(aeronmd
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${AERON_C_CLIENT_SOURCE_PATH})
 
-add_executable(aeronmd_s aeronmd.c)
-target_include_directories(aeronmd_s
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${AERON_C_CLIENT_SOURCE_PATH})
+# add_executable(aeronmd_s aeronmd.c)
+# target_include_directories(aeronmd_s
+# PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${AERON_C_CLIENT_SOURCE_PATH})
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DDISABLE_BOUNDS_CHECKS")
 
@@ -369,11 +369,16 @@ endif ()
 find_package(PkgConfig)
 ## use pkg-config to get hints for 0mq locations
 pkg_check_modules(PC_ZeroMQ QUIET zmq)
+pkg_check_modules(PC_Sodium QUIET sodium)
 
 ## use the hint from above to find the location of libzmq
 find_library(ZeroMQ_LIBRARY
         NAMES zmq
         PATHS ${PC_ZeroMQ_LIBRARY_DIRS}
+        )
+find_library(Sodium_LIBRARY
+        NAMES sodium 
+        PATHS ${PC_Sodium_LIBRARY_DIRS}
         )
 
 target_link_libraries(
@@ -385,7 +390,8 @@ target_link_libraries(
     ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS}
-    ${ZeroMQ_LIBRARY})
+    ${ZeroMQ_LIBRARY}
+    ${Sodium_LIBRARY})
 
 target_link_libraries(
     aeronmd
@@ -397,19 +403,21 @@ target_link_libraries(
     ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS}
-    ${ZeroMQ_LIBRARY})
+    ${ZeroMQ_LIBRARY}
+    ${Sodium_LIBRARY})
 
-target_link_libraries(
-    aeronmd_s
-    aeron_driver_static
-    ${CMAKE_DL_LIBS}
-    ${AERON_LIB_BSD_LIBS}
-    ${AERON_LIB_UUID_LIBS}
-    ${AERON_LIB_M_LIBS}
-    ${AERON_LIB_ATOMIC_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${AERON_LIB_WINSOCK_LIBS}
-    ${ZeroMQ_LIBRARY})
+# target_link_libraries(
+#  aeronmd_s
+#  aeron_driver_static
+#    ${CMAKE_DL_LIBS}
+#    ${AERON_LIB_BSD_LIBS}
+#    ${AERON_LIB_UUID_LIBS}
+#    ${AERON_LIB_M_LIBS}
+#    ${AERON_LIB_ATOMIC_LIBS}
+#    ${CMAKE_THREAD_LIBS_INIT}
+#    ${AERON_LIB_WINSOCK_LIBS}
+#    ${ZeroMQ_LIBRARY}
+#    ${Sodium_LIBRARY})
 
 target_compile_definitions(aeron_driver PRIVATE -DAERON_DRIVER)
 target_compile_definitions(aeron_driver_static PRIVATE -DAERON_DRIVER)
@@ -420,6 +428,7 @@ if (AERON_INSTALL_TARGETS)
         RUNTIME DESTINATION lib
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
-    install(TARGETS aeronmd aeronmd_s DESTINATION bin)
+    install(TARGETS aeronmd DESTINATION bin)
+    # install(TARGETS aeronmd aeronmd_s DESTINATION bin)
     install(DIRECTORY . DESTINATION include/aeronmd FILES_MATCHING PATTERN "*.h")
 endif ()

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -16,6 +16,9 @@ include(CheckSymbolExists)
 include(CheckIncludeFile)
 include(CheckTypeSize)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
     add_definitions(-D_DEFAULT_SOURCE)
@@ -330,9 +333,9 @@ add_library(aeron_driver SHARED ${SOURCE} ${HEADERS})
 target_include_directories(aeron_driver
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${AERON_C_CLIENT_SOURCE_PATH})
 
-add_library(aeron_driver_static STATIC ${SOURCE} ${HEADERS})
-target_include_directories(aeron_driver_static
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${AERON_C_CLIENT_SOURCE_PATH})
+# add_library(aeron_driver_static STATIC ${SOURCE} ${HEADERS})
+#target_include_directories(aeron_driver_static
+#  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${AERON_C_CLIENT_SOURCE_PATH})
 
 add_executable(aeronmd aeronmd.c)
 target_include_directories(aeronmd
@@ -420,11 +423,12 @@ target_link_libraries(
 #    ${Sodium_LIBRARY})
 
 target_compile_definitions(aeron_driver PRIVATE -DAERON_DRIVER)
-target_compile_definitions(aeron_driver_static PRIVATE -DAERON_DRIVER)
+# target_compile_definitions(aeron_driver_static PRIVATE -DAERON_DRIVER)
 
 if (AERON_INSTALL_TARGETS)
     install(
-        TARGETS aeron_driver aeron_driver_static
+        TARGETS aeron_driver
+        # TARGETS aeron_driver aeron_driver_static
         RUNTIME DESTINATION lib
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -658,6 +658,7 @@ int aeron_driver_conductor_init(aeron_driver_conductor_t *conductor, aeron_drive
 
     conductor->context = context;
 
+    // Create ZMQ notification socket.
     void *ctx = zmq_ctx_new ();
     conductor->notify_socket = zmq_socket (ctx, ZMQ_PUB);
     char buf[1024];
@@ -2838,14 +2839,20 @@ int aeron_driver_conductor_do_work(void *clientd)
     for (size_t i = 0, length = conductor->publication_images.length; i < length; i++)
     {
         aeron_publication_image_t* image = conductor->publication_images.array[i].image;
+        // If rcv-pos increased (new completed data), mark this stream as updated.
+        // Different publication images could be subscribed to the same stream, but usually they will be updated at the
+        // same time here, which means that duplicate notifications generally don't occur.
         if (aeron_publication_image_track_rebuild(image, now_ns)) {
             notify_data_t* notify = aeron_int64_to_ptr_hash_map_get(&conductor->stream_id_notify_map, (int64_t)image->stream_id);
             notify->updated = true;
         }
     }
+
+    // Send ZMQ notification for any streams that have been updated.
     for (size_t i = 0; i < conductor->stream_id_notify_map.capacity; i++) {
         notify_data_t* notify = conductor->stream_id_notify_map.values[i];
         if (notify != NULL && notify->updated) {
+            // For debug..
             // int64_t stream_id = conductor->stream_id_notify_map.keys[i];
             // printf("%d\n", stream_id);
 
@@ -4534,10 +4541,12 @@ void aeron_driver_conductor_on_create_publication_image(void *clientd, void *ite
     bool is_oldest_subscription_sparse = aeron_driver_conductor_is_oldest_subscription_sparse(
         conductor, endpoint, command->stream_id, command->session_id, registration_id);
 
+    // Handle new stream for notification.
     notify_data_t* notify = aeron_int64_to_ptr_hash_map_get(&conductor->stream_id_notify_map, (int64_t)command->stream_id);
     if (NULL == notify) {
         notify = malloc(sizeof(notify_data_t));
         notify->updated = false;
+        // The notify message is hardcoded to the stream_id (as a string).
         snprintf(notify->message, sizeof(notify->message), "%d", command->stream_id);
         printf("New stream: %d\n", command->stream_id);
 

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -31,6 +31,7 @@
 
 #include "util/aeron_math.h"
 #include "util/aeron_arrayutil.h"
+#include "aeron_alloc.h"
 #include "aeron_driver_conductor.h"
 #include "aeron_position.h"
 #include "aeron_driver_sender.h"
@@ -38,6 +39,8 @@
 #include "collections/aeron_bit_set.h"
 #include "uri/aeron_uri.h"
 #include "util/aeron_parse_util.h"
+#include <sys/socket.h>
+#include <sys/un.h>
 
 
 #define STATIC_BIT_SET_U64_LEN (512u)
@@ -444,6 +447,13 @@ int aeron_driver_conductor_init(aeron_driver_conductor_t *conductor, aeron_drive
     {
         return -1;
     }
+
+    if (aeron_int64_to_ptr_hash_map_init(
+        &conductor->stream_id_socket_map, 64, AERON_MAP_DEFAULT_LOAD_FACTOR) < 0)
+    {
+        return -1;
+    }
+
 
     if (aeron_loss_reporter_init(&conductor->loss_reporter, context->loss_report.addr, context->loss_report.length) < 0)
     {
@@ -2898,6 +2908,7 @@ void aeron_driver_conductor_on_close(void *clientd)
 
     aeron_str_to_ptr_hash_map_delete(&conductor->send_channel_endpoint_by_channel_map);
     aeron_str_to_ptr_hash_map_delete(&conductor->receive_channel_endpoint_by_channel_map);
+    aeron_int64_to_ptr_hash_map_delete(&conductor->stream_id_socket_map);
     aeron_mpsc_rb_consumer_heartbeat_time(&conductor->to_driver_commands, AERON_NULL_VALUE);
 }
 
@@ -4502,6 +4513,23 @@ void aeron_driver_conductor_on_create_publication_image(void *clientd, void *ite
         endpoint->conductor_fields.udp_channel->is_multicast : AERON_FORCE_TRUE == group_subscription;
     bool is_oldest_subscription_sparse = aeron_driver_conductor_is_oldest_subscription_sparse(
         conductor, endpoint, command->stream_id, command->session_id, registration_id);
+
+    int* socket_fd = aeron_int64_to_ptr_hash_map_get(&conductor->stream_id_socket_map, (int64_t)command->stream_id);
+    if (NULL == socket_fd) {
+        printf("Creating socket: %d\n", command->stream_id);
+        char buffer[1024];
+        snprintf(buffer, sizeof(buffer), "/tmp/socket-%d", command->stream_id);
+        struct sockaddr_un server_addr;
+        memset(&server_addr, 0, sizeof(server_addr));
+        server_addr.sun_family = AF_UNIX;
+        strncpy(server_addr.sun_path, buffer, 104);
+
+        socket_fd = malloc(sizeof(int));
+        *socket_fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+        bind(*socket_fd, (struct sockaddr *) &server_addr, sizeof(server_addr));
+
+        aeron_int64_to_ptr_hash_map_put(&conductor->stream_id_socket_map, (int64_t)command->stream_id, socket_fd);
+    }
 
     aeron_publication_image_t *image = NULL;
     if (aeron_publication_image_create(

--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -153,6 +153,12 @@ aeron_linger_resource_entry_t;
 
 typedef struct aeron_driver_conductor_stct aeron_driver_conductor_t;
 
+typedef struct notify_data_stct {
+    bool updated;
+    void* socket;
+    char buf[64];
+} notify_data_t; 
+
 typedef struct aeron_driver_conductor_stct
 {
     aeron_driver_context_t *context;

--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -153,6 +153,7 @@ aeron_linger_resource_entry_t;
 
 typedef struct aeron_driver_conductor_stct aeron_driver_conductor_t;
 
+// Notification-related state.
 typedef struct notify_data_stct {
     bool updated;
     char message[64];
@@ -297,6 +298,7 @@ typedef struct aeron_driver_conductor_stct
     uint8_t padding[AERON_CACHE_LINE_LENGTH];
 
     aeron_int64_to_ptr_hash_map_t stream_id_notify_map;
+    // ZMQ socket for publishing notifications.
     void* notify_socket;
 }
 aeron_driver_conductor_t;

--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -155,8 +155,7 @@ typedef struct aeron_driver_conductor_stct aeron_driver_conductor_t;
 
 typedef struct notify_data_stct {
     bool updated;
-    void* socket;
-    char buf[64];
+    char message[64];
 } notify_data_t; 
 
 typedef struct aeron_driver_conductor_stct
@@ -297,7 +296,8 @@ typedef struct aeron_driver_conductor_stct
 
     uint8_t padding[AERON_CACHE_LINE_LENGTH];
 
-    aeron_int64_to_ptr_hash_map_t stream_id_socket_map;
+    aeron_int64_to_ptr_hash_map_t stream_id_notify_map;
+    void* notify_socket;
 }
 aeron_driver_conductor_t;
 

--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -27,6 +27,7 @@
 #include "aeron_system_counters.h"
 #include "aeron_ipc_publication.h"
 #include "collections/aeron_str_to_ptr_hash_map.h"
+#include "collections/aeron_int64_to_ptr_hash_map.h"
 #include "media/aeron_send_channel_endpoint.h"
 #include "media/aeron_receive_channel_endpoint.h"
 #include "aeron_driver_conductor_proxy.h"
@@ -289,6 +290,8 @@ typedef struct aeron_driver_conductor_stct
     int64_t last_consumer_command_position;
 
     uint8_t padding[AERON_CACHE_LINE_LENGTH];
+
+    aeron_int64_to_ptr_hash_map_t stream_id_socket_map;
 }
 aeron_driver_conductor_t;
 

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -23,6 +23,7 @@
 #include "aeron_driver_conductor.h"
 #include "concurrent/aeron_term_gap_filler.h"
 #include <sys/socket.h>
+#include <zmq.h>
 
 static void aeron_publication_image_connection_set_control_address(
     aeron_publication_image_connection_t *connection, const struct sockaddr_storage *control_address)
@@ -390,9 +391,10 @@ void aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int
 
         bool updated = aeron_counter_propose_max_ordered(image->rcv_pos_position.value_addr, new_rebuild_position);
         if (updated) {
-            // int buflen = snprintf(image->notify_socket_buf, sizeof(image->notify_socket_buf), "%ld", new_rebuild_position);
-            // write(*image->notify_socket_fd, image->notify_socket_buf, buflen);
-            // printf("%d: %ld\n", image->stream_id, new_rebuild_position);
+            int buflen = snprintf(image->notify_socket_buf, sizeof(image->notify_socket_buf), "%ld", new_rebuild_position);
+
+             zmq_send(image->notify_socket_fd, image->notify_socket_buf, buflen, 0);
+            // printf("%d: %ld [%d]\n", image->stream_id, new_rebuild_position, rc);
         }
 
         bool should_force_send_sm = false;

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -384,6 +384,7 @@ bool aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int
         const int32_t rebuild_term_offset = (int32_t)(rebuild_position & image->term_length_mask);
         const int64_t new_rebuild_position = (rebuild_position - rebuild_term_offset) + rebuild_offset;
 
+        // This is the rcv-pos increased counter, which is essentially the signal that new data can be polled.
         bool updated = aeron_counter_propose_max_ordered(image->rcv_pos_position.value_addr, new_rebuild_position);
 
         bool should_force_send_sm = false;

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -76,7 +76,7 @@ int aeron_publication_image_create(
     bool is_sparse,
     bool treat_as_multicast,
     aeron_system_counters_t *system_counters,
-    int* notify_socket_fd)
+    void* notify_socket_fd)
 {
     aeron_publication_image_t *_image = NULL;
     const uint64_t log_length = aeron_logbuffer_compute_log_length(
@@ -390,8 +390,8 @@ void aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int
 
         bool updated = aeron_counter_propose_max_ordered(image->rcv_pos_position.value_addr, new_rebuild_position);
         if (updated) {
-            int buflen = snprintf(image->notify_socket_buf, sizeof(image->notify_socket_buf), "%ld", new_rebuild_position);
-            write(*image->notify_socket_fd, image->notify_socket_buf, buflen);
+            // int buflen = snprintf(image->notify_socket_buf, sizeof(image->notify_socket_buf), "%ld", new_rebuild_position);
+            // write(*image->notify_socket_fd, image->notify_socket_buf, buflen);
             // printf("%d: %ld\n", image->stream_id, new_rebuild_position);
         }
 

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -384,7 +384,10 @@ void aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int
         const int32_t rebuild_term_offset = (int32_t)(rebuild_position & image->term_length_mask);
         const int64_t new_rebuild_position = (rebuild_position - rebuild_term_offset) + rebuild_offset;
 
-        aeron_counter_propose_max_ordered(image->rcv_pos_position.value_addr, new_rebuild_position);
+        bool updated = aeron_counter_propose_max_ordered(image->rcv_pos_position.value_addr, new_rebuild_position);
+        if (updated) {
+            // printf("%d: %ld\n", image->stream_id, new_rebuild_position);
+        }
 
         bool should_force_send_sm = false;
         const int32_t window_length = image->congestion_control->on_track_rebuild(

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -385,6 +385,7 @@ bool aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int
         const int64_t new_rebuild_position = (rebuild_position - rebuild_term_offset) + rebuild_offset;
 
         // This is the rcv-pos increased counter, which is essentially the signal that new data can be polled.
+        // See: https://aeroncookbook.com/aeron/aeron-understanding-position/
         bool updated = aeron_counter_propose_max_ordered(image->rcv_pos_position.value_addr, new_rebuild_position);
 
         bool should_force_send_sm = false;

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -131,9 +131,6 @@ typedef struct aeron_publication_image_stct
     int64_t *status_messages_sent_counter;
     int64_t *nak_messages_sent_counter;
     int64_t *loss_gap_fills_counter;
-
-    void* notify_socket_fd;
-    char notify_socket_buf[1024];
 }
 aeron_publication_image_t;
 
@@ -159,8 +156,7 @@ int aeron_publication_image_create(
     bool is_reliable,
     bool is_sparse,
     bool treat_as_multicast,
-    aeron_system_counters_t *system_counters,
-    void* notify_socket_fd);
+    aeron_system_counters_t *system_counters);
 
 int aeron_publication_image_close(aeron_counters_manager_t *counters_manager, aeron_publication_image_t *image);
 
@@ -168,7 +164,7 @@ void aeron_publication_image_clean_buffer_to(aeron_publication_image_t *image, i
 
 void aeron_publication_image_on_gap_detected(void *clientd, int32_t term_id, int32_t term_offset, size_t length);
 
-void aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int64_t now_ns);
+bool aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int64_t now_ns);
 
 int aeron_publication_image_insert_packet(
     aeron_publication_image_t *image,

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -132,7 +132,7 @@ typedef struct aeron_publication_image_stct
     int64_t *nak_messages_sent_counter;
     int64_t *loss_gap_fills_counter;
 
-    int* notify_socket_fd;
+    void* notify_socket_fd;
     char notify_socket_buf[1024];
 }
 aeron_publication_image_t;
@@ -160,7 +160,7 @@ int aeron_publication_image_create(
     bool is_sparse,
     bool treat_as_multicast,
     aeron_system_counters_t *system_counters,
-    int* notify_socket_fd);
+    void* notify_socket_fd);
 
 int aeron_publication_image_close(aeron_counters_manager_t *counters_manager, aeron_publication_image_t *image);
 

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -131,6 +131,9 @@ typedef struct aeron_publication_image_stct
     int64_t *status_messages_sent_counter;
     int64_t *nak_messages_sent_counter;
     int64_t *loss_gap_fills_counter;
+
+    int* notify_socket_fd;
+    char notify_socket_buf[1024];
 }
 aeron_publication_image_t;
 
@@ -156,7 +159,8 @@ int aeron_publication_image_create(
     bool is_reliable,
     bool is_sparse,
     bool treat_as_multicast,
-    aeron_system_counters_t *system_counters);
+    aeron_system_counters_t *system_counters,
+    int* notify_socket_fd);
 
 int aeron_publication_image_close(aeron_counters_manager_t *counters_manager, aeron_publication_image_t *image);
 


### PR DESCRIPTION
Publishes notifications on ZMQ IPC transport `ipc:///tmp/aeron-notify` whenever there is new data to be polled for any stream being tracked by any local publication image (the subscription incoming data).

It uses a single ZMQ endpoint (instead of per-stream) to avoid having the clients create too many zmq sockets, which degrades performance.

Regarding how to understand Aeron positional counters `rcv-pos`, see:
https://aeroncookbook.com/aeron/aeron-understanding-position/

Will be combined with https://github.com/un-noted/trading/pull/881

/cc https://github.com/orgs/un-noted/teams/all